### PR TITLE
Drop call to appstreamcli refresh

### DIFF
--- a/InstallAppdata.py
+++ b/InstallAppdata.py
@@ -47,7 +47,3 @@ except IndexError:
 # Fixup icon that might have uncompressed with odd permissions
 for icondir in glob.glob('/var/cache/app-info/icons/*'):
   os.chmod(icondir, 0o755)
-
-# (Re)create the Xapian database required by the KDE tools
-os.system("/usr/bin/appstreamcli refresh-cache")
-

--- a/appstream-sync-cache.service
+++ b/appstream-sync-cache.service
@@ -4,6 +4,19 @@ After=local-fs.target
 ConditionDirectoryNotEmpty=!/var/cache/app-info/xmls
 
 [Service]
+# added automatically, for details please see
+# https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
+# end of automatic additions
 Type=forking
 ExecStart=/usr/bin/zypper appstream-cache
 


### PR DESCRIPTION
AppStream 0.14.2 introduced a user metadata cache, which does a much better job
than the system cache, so don't bother with the system cache at all.

Also upstream harden_appstream-sync-cache.service.patch.